### PR TITLE
Provide extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
 		},
 		"typo3/cms": {
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
+			"extension-key": "pdfviewhelpers",
 			"web-dir": ".Build/Web"
 		}
 	}


### PR DESCRIPTION
This change will become mandatory in future versions of TYPO3.
It is documented at https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra.
Adding it now removed the yellow warning when installing via composer:

    The TYPO3 extension package "bithost-gmbh/pdfviewhelpers", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)