### PR TITLE
Add middleware as replacement for isOutputting hook in v11

### DIFF
--- a/Classes/Middleware/PdfViewHelpersStopOutputMiddleware.php
+++ b/Classes/Middleware/PdfViewHelpersStopOutputMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bithost\Pdfviewhelpers\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\NullResponse;
+
+class PdfViewHelpersStopOutputMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+        if ($GLOBALS['TSFE']->applicationData['tx_pdfviewhelpers']['pdfOutput'] ?? false) {
+            return new NullResponse();
+        }
+        return $response;
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'frontend' => [
+        'pdfviewhelpers' => [
+            'target' => \Bithost\Pdfviewhelpers\Middleware\PdfViewHelpersStopOutputMiddleware::class,
+            'after' => 'typo3/cms-frontend/page-argument-validator'
+        ]
+    ]
+];


### PR DESCRIPTION
The hook is deprecated in v10 and removed in v11.
As a replacement a middleware needs to be implemented.