### PR TITLE
Prevent undefined array key warning under PHP 8.0

### DIFF
--- a/Classes/Middleware/Frontend/StopOutputMiddleware.php
+++ b/Classes/Middleware/Frontend/StopOutputMiddleware.php
@@ -19,7 +19,7 @@ class StopOutputMiddleware implements MiddlewareInterface
         $response = $handler->handle($request);
 
         if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 11
-            && $GLOBALS['TSFE']->applicationData['tx_pdfviewhelpers']['pdfOutput'] ?? false
+            && ($GLOBALS['TSFE']->applicationData['tx_pdfviewhelpers']['pdfOutput'] ?? false)
         ) {
             return new NullResponse();
         }


### PR DESCRIPTION
Resolves #198

This fixes the regression that has appeared in version 2.4.0 when an additional check was implemented in StopOutputMiddleware. An additional pair of braces has been added to prevent the higher operator precedence of && from taking place.
