### PR TITLE
Add listIndentWidth argument to HtmlViewHelper.

### DIFF
--- a/Classes/ViewHelpers/HtmlViewHelper.php
+++ b/Classes/ViewHelpers/HtmlViewHelper.php
@@ -114,7 +114,7 @@ class HtmlViewHelper extends AbstractContentElementViewHelper
         $this->getPDF()->setCellPaddings(0, 0, 0, 0); //reset padding to avoid errors on nested tags
         $this->getPDF()->setCellHeightRatio($this->settings['generalText']['lineHeight']);
         $this->getPDF()->setFontSpacing($this->settings['generalText']['characterSpacing']);
-        if(!empty($this->arguments['listIndentWidth'])) {
+        if (!empty($this->arguments['listIndentWidth'])) {
             $this->getPDF()->setListIndentWidth($this->arguments['listIndentWidth']);
         }
 

--- a/Classes/ViewHelpers/HtmlViewHelper.php
+++ b/Classes/ViewHelpers/HtmlViewHelper.php
@@ -49,6 +49,7 @@ class HtmlViewHelper extends AbstractContentElementViewHelper
         $this->registerArgument('autoHyphenation', 'boolean', 'If true the text will be hyphenated automatically.', false, (bool) $this->settings['generalText']['autoHyphenation']);
         $this->registerArgument('styleSheet', 'string', 'The path to an external style sheet being used to style this HTML content.', false, $this->settings['html']['styleSheet']);
         $this->registerArgument('padding', 'array', 'The padding of the HTML element as array.', false, null);
+        $this->registerArgument('listIndentWidth', 'float', 'Set custom width for list indentation.', false, null);
 
         if (strlen((string) $this->settings['html']['autoHyphenation'])) {
             $this->overrideArgument('autoHyphenation', 'boolean', '', false, (bool) $this->settings['html']['autoHyphenation']);
@@ -113,6 +114,9 @@ class HtmlViewHelper extends AbstractContentElementViewHelper
         $this->getPDF()->setCellPaddings(0, 0, 0, 0); //reset padding to avoid errors on nested tags
         $this->getPDF()->setCellHeightRatio($this->settings['generalText']['lineHeight']);
         $this->getPDF()->setFontSpacing($this->settings['generalText']['characterSpacing']);
+        if(isset($this->arguments['listIndentWidth'])) {
+            $this->getPDF()->setListIndentWidth($this->arguments['listIndentWidth']);
+        }
 
         $this->getPDF()->setY($this->arguments['posY'] + $this->arguments['padding']['top']);
 

--- a/Classes/ViewHelpers/HtmlViewHelper.php
+++ b/Classes/ViewHelpers/HtmlViewHelper.php
@@ -49,7 +49,7 @@ class HtmlViewHelper extends AbstractContentElementViewHelper
         $this->registerArgument('autoHyphenation', 'boolean', 'If true the text will be hyphenated automatically.', false, (bool) $this->settings['generalText']['autoHyphenation']);
         $this->registerArgument('styleSheet', 'string', 'The path to an external style sheet being used to style this HTML content.', false, $this->settings['html']['styleSheet']);
         $this->registerArgument('padding', 'array', 'The padding of the HTML element as array.', false, null);
-        $this->registerArgument('listIndentWidth', 'float', 'Set custom width for list indentation.', false, null);
+        $this->registerArgument('listIndentWidth', 'float', 'Set custom width for list indentation.', false, $this->settings['html']['listIndentWidth']);
 
         if (strlen((string) $this->settings['html']['autoHyphenation'])) {
             $this->overrideArgument('autoHyphenation', 'boolean', '', false, (bool) $this->settings['html']['autoHyphenation']);
@@ -114,7 +114,7 @@ class HtmlViewHelper extends AbstractContentElementViewHelper
         $this->getPDF()->setCellPaddings(0, 0, 0, 0); //reset padding to avoid errors on nested tags
         $this->getPDF()->setCellHeightRatio($this->settings['generalText']['lineHeight']);
         $this->getPDF()->setFontSpacing($this->settings['generalText']['characterSpacing']);
-        if(isset($this->arguments['listIndentWidth'])) {
+        if(!empty($this->arguments['listIndentWidth'])) {
             $this->getPDF()->setListIndentWidth($this->arguments['listIndentWidth']);
         }
 

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -187,6 +187,7 @@ plugin.tx_pdfviewhelpers.settings {
 	html {
 		autoHyphenation =
 		styleSheet =
+		listIndentWidth =
 		padding {
 			top = 0
 			right = 0

--- a/Documentation/ConfigurationReference/TypoScriptReference/Index.rst
+++ b/Documentation/ConfigurationReference/TypoScriptReference/Index.rst
@@ -134,7 +134,7 @@ Properties in plugin.tx_pdfviewhelpers.settings
 	image.processingInstructions_                  Array                                 {}
 	html.autoHyphenation                           :ref:`t3tsref:data-type-boolean`      *See generalText*
 	html.styleSheet_                               :ref:`t3tsref:data-type-string`
-	html.listIndentWidth_                          :ref:`t3tsref:data-type-integer`
+	html.listIndentWidth_                          :ref:`t3tsref:data-type-float`
 	html.padding_                                  Array                                 {top: 0, right: 0, bottom: 2, left: 0}
 	graphics.line.padding_                         Array                                 {top: 4, right: 0, bottom: 5, left: 0}
 	graphics.line.style_                           Array                                 {width: 0.25, color: #000}

--- a/Documentation/ConfigurationReference/TypoScriptReference/Index.rst
+++ b/Documentation/ConfigurationReference/TypoScriptReference/Index.rst
@@ -134,6 +134,7 @@ Properties in plugin.tx_pdfviewhelpers.settings
 	image.processingInstructions_                  Array                                 {}
 	html.autoHyphenation                           :ref:`t3tsref:data-type-boolean`      *See generalText*
 	html.styleSheet_                               :ref:`t3tsref:data-type-string`
+	html.listIndentWidth_                          :ref:`t3tsref:data-type-integer`
 	html.padding_                                  Array                                 {top: 0, right: 0, bottom: 2, left: 0}
 	graphics.line.padding_                         Array                                 {top: 4, right: 0, bottom: 5, left: 0}
 	graphics.line.style_                           Array                                 {width: 0.25, color: #000}

--- a/Documentation/ViewHelpers/HtmlViewHelper/Index.rst
+++ b/Documentation/ViewHelpers/HtmlViewHelper/Index.rst
@@ -24,7 +24,7 @@ Please note that the use of CSS within a style tag can lead to parsing issues wi
 **Advanced Usage**
 ::
 
-	<pdf:html styleSheet="fileadmin/template/pdf_styles.css" autoHyphenation="1" padding="{bottom: 5}">
+	<pdf:html styleSheet="fileadmin/template/pdf_styles.css" autoHyphenation="1" padding="{bottom: 5}" listIndentWidth="0">
 		<style>
 			h1 {
 				color: #ff642c;


### PR DESCRIPTION
Introduces a listIndentWidth argument which is passed to TCPDF::setListIndentWidth.
This is needed because the indentation of lists cannot be overwritten with pure CSS.