### PR TITLE
FEAT Adapt for TYPO3 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
           - { TYPO3_VERSION: 12, PHP_VERSION: 8.1 }
           - { TYPO3_VERSION: 12, PHP_VERSION: 8.2 }
           - { TYPO3_VERSION: 12, PHP_VERSION: 8.3 }
+          - { TYPO3_VERSION: 13, PHP_VERSION: 8.2 }
+          - { TYPO3_VERSION: 13, PHP_VERSION: 8.3 }
+          - { TYPO3_VERSION: 13, PHP_VERSION: 8.4 }
 
     env:
       TCPDF_VERSION: 6.6.2

--- a/Configuration/TypoScript/Extensions/News/setup.typoscript
+++ b/Configuration/TypoScript/Extensions/News/setup.typoscript
@@ -1,4 +1,4 @@
-[getTSFE() && getTSFE().type == 28032013]
+[request && traverse(request.getQueryParams(), 'type') == 28032013]
 	pageNewsPDF = PAGE
 	pageNewsPDF {
 		typeNum = 28032013

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^11.5 || ^12.4",
+		"typo3/cms-core": "^11.5 || ^12.4 || ^13.4",
 		"php": ">=7.4.0",
 		"tecnickcom/tcpdf": "^6.2",
 		"setasign/fpdi": "^2.0"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
 	'version' => '3.0.0',
 	'constraints' => [
 		'depends' => [
-			'typo3' => '11.5.0-12.4.99',
+			'typo3' => '11.5.0-13.4.99',
 			'php' => '7.4.0-0.0.0',
 		],
 		'conflicts' => [],


### PR DESCRIPTION
Hi @maechler 

As you suggested to my colleague in #249, we gave it a shot and it worked quite well. With only one simple modification, I was able to get the extension up and running on TYPO3 13.4.0. The manual testing I did was to render all the examples form Resources/Public/Examples as well as the news integration for a basic news article. As far as I can see, the automated tests should run after I create this PR via Github Actions, so let's see if that will reveal further issues...