### PR TITLE
[BUGFIX] make route enhancers work again (fixes #260)

### DIFF
--- a/Configuration/TypoScript/Extensions/News/setup.typoscript
+++ b/Configuration/TypoScript/Extensions/News/setup.typoscript
@@ -1,4 +1,4 @@
-[request && traverse(request.getQueryParams(), 'type') == 28032013]
+[request && request.getPageArguments()?.getPageType() == 28032013]
 	pageNewsPDF = PAGE
 	pageNewsPDF {
 		typeNum = 28032013

--- a/Documentation/ConfigurationReference/ExtNews/Index.rst
+++ b/Documentation/ConfigurationReference/ExtNews/Index.rst
@@ -31,7 +31,7 @@ Please make sure that all your configuration is limited to the page type ``28032
 
 ::
 
-	[request && traverse(request.getQueryParams(), 'type') == 28032013]
+	[request && request.getPageArguments()?.getPageType() == 28032013]
 		plugin.tx_pdfviewhelpers.settings {
 			text {
 				types {
@@ -61,7 +61,7 @@ that is located in ``EXT:yourext/Resources/Private/Templates/Extensions/News/Tem
 
 ::
 
-	[request && traverse(request.getQueryParams(), 'type') == 28032013]
+	[request && request.getPageArguments()?.getPageType() == 28032013]
 		plugin.tx_news {
 			view {
 				templateRootPaths {


### PR DESCRIPTION
You should use request.getPageType() instead of reading the type from query params. If you want to work with route enhancers the type cannot be read from the query params.

The replacement of `[getTSFE() && getTSFE().type == 28032013]` with `[request && traverse(request.getQueryParams(), 'type') == 28032013]` since version `3.1.0` broke the compatibility with route enhancers.

fixes #260 